### PR TITLE
Implement PR-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,8 @@ name: release
 
 on:
   push:
-    tags:
-      - "v*.*.*"          # Stable releases
-      - "v*.*.*-beta.*"   # Beta releases
-      - "v*.*.*-alpha.*"  # Alpha releases
+    branches:
+      - main
 
 jobs:
   publish:
@@ -15,32 +13,45 @@ jobs:
       id-token: write   # for npm provenance
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all history and tags
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - run: npm ci
-
-      - name: Verify tag matches package.json version
+      - name: Check if version changed
+        id: version-check
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "❌ Tag version (v$TAG_VERSION) doesn't match package.json ($PKG_VERSION)"
-            echo "This should not happen if using 'npm version' commands"
-            exit 1
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+          # Get previous version from the commit before this one
+          git checkout HEAD^
+          PREVIOUS_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "none")
+          git checkout -
+
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+            echo "✅ Version changed: $PREVIOUS_VERSION → $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No version change detected"
           fi
-          echo "✅ Version verified: $TAG_VERSION"
 
       - name: Run tests
-        run: npm run execute-tests
+        if: steps.version-check.outputs.changed == 'true'
+        run: |
+          npm ci
+          npm run execute-tests
 
       - name: Determine npm dist-tag
+        if: steps.version-check.outputs.changed == 'true'
         id: dist-tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ steps.version-check.outputs.version }}"
           if [[ "$VERSION" == *"beta"* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "📦 Publishing to npm @beta"
@@ -53,16 +64,26 @@ jobs:
           fi
 
       - name: Publish to npm
+        if: steps.version-check.outputs.changed == 'true'
         run: npm publish --access public --provenance --tag ${{ steps.dist-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create GitHub Release
+      - name: Create Git tag
+        if: steps.version-check.outputs.changed == 'true'
         run: |
+          VERSION="${{ steps.version-check.outputs.version }}"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub Release
+        if: steps.version-check.outputs.changed == 'true'
+        run: |
+          VERSION="${{ steps.version-check.outputs.version }}"
           if [[ "${{ steps.dist-tag.outputs.tag }}" != "latest" ]]; then
-            gh release create ${{ github.ref_name }} --title "Release ${{ github.ref_name }}" --prerelease
+            gh release create "v$VERSION" --title "Release v$VERSION" --prerelease
           else
-            gh release create ${{ github.ref_name }} --title "Release ${{ github.ref_name }}"
+            gh release create "v$VERSION" --title "Release v$VERSION"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,16 +35,18 @@ Configuration inheritance structure:
 ### Release Management
 
 ```bash
-# Create beta release (for feature branches)
-npm run release:beta
-
-# Create stable releases (from main branch only)
+# Create stable releases (from main branch, creates release branch + PR)
 npm run release:patch    # 0.5.0 → 0.5.1
 npm run release:minor    # 0.5.0 → 0.6.0
 npm run release:major    # 0.5.0 → 1.0.0
 
-# Promote beta to stable
-npm version 0.5.0
+# After running above, create PR:
+gh pr create --title "Release v0.5.1" --body "Release version 0.5.1"
+
+# Merge PR → automatic npm publish + GitHub release
+
+# Create beta release (for feature branches)
+npm run release:beta
 
 # Run tests manually
 npm run execute-tests
@@ -83,17 +85,22 @@ Both test projects contain various file types (`.js`, `.jsx`, `.ts`, `.mts`, `.c
 
 ## Release Workflow
 
-The release process is fully automated through npm scripts and GitHub Actions:
+The release process requires PR approval before publishing to npm:
 
-1. **Local:** Run `npm run release:*` or `npm version`
-2. **Preversion:** Tests run automatically via `execute-tests.mjs`
-3. **Version:** package.json updated and git tag created
-4. **Postversion:** Changes pushed to GitHub with tag
-5. **GitHub Actions:** Workflow triggered by tag push
-6. **CI/CD:** Tests run again, package published to npm with provenance
-7. **GitHub:** Release created automatically
+1. **Local:** Run `npm run release:*` from main branch
+2. **Preversion:** Checks for uncommitted changes (blocks if any), then runs tests
+3. **Version:** package.json updated, commit created on main
+4. **Postversion:** Creates `release/v*` branch, deletes local tag, pushes branch
+5. **Manual:** Create PR from release branch → main
+6. **Review:** PR must be approved and merged
+7. **GitHub Actions:** Detects version change on main after merge
+8. **CI/CD:** Runs tests, publishes to npm with provenance
+9. **GitHub Actions:** Creates git tag on main
+10. **GitHub Actions:** Creates GitHub Release
 
-**Important:** Never create git tags manually. Always use npm version commands.
+**Important:**
+- You must have no uncommitted changes when running npm version commands
+- Releases only publish after PR is merged to main (provides review checkpoint)
 
 ## Configuration Details
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "execute-tests": "utils/execute-tests.mjs",
-    "preversion": "npm run execute-tests",
+    "preversion": "git diff-index --quiet HEAD -- || (echo '❌ Error: Uncommitted changes detected. Please commit or stash your changes before running npm version.' && exit 1) && npm run execute-tests",
     "version": "git add package.json",
-    "postversion": "git push && git push --tags",
+    "postversion": "VERSION=$(node -p \"require('./package.json').version\") && BRANCH=\"release/v$VERSION\" && git checkout -b \"$BRANCH\" && git tag -d \"v$VERSION\" && git push -u origin \"$BRANCH\" && git checkout main",
     "release:beta": "npm version prerelease --preid=beta",
     "release:patch": "npm version patch",
     "release:minor": "npm version minor",


### PR DESCRIPTION
## Summary

Updates the release workflow to require PR approval before publishing to npm.

## Changes

### Workflow Updates
- Release workflow now triggers on main push (instead of tag push)
- Detects version changes automatically
- Only publishes to npm after PR is merged to main
- Creates git tag on main after successful publish

### Safety Improvements
- Added uncommitted changes check in preversion
- Prevents accidental releases with dirty working directory
- Creates release branch automatically for review

### Process Flow
1. Run `npm run release:patch` from main
2. Automatically creates `release/v*` branch
3. Create PR from release branch → main
4. After PR merged → automatic npm publish + GitHub release

## Documentation
- Updated README.md with new workflow
- Updated CLAUDE.md with PR-based process
- Added safety warnings about uncommitted changes