### PR TITLE
fix: add repository type field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "repository": {
+    "type": "git",
     "url": "https://github.com/paretio/tsconfig"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds missing 'type' field to repository configuration in package.json to avoid npm warning during publish.