### PR TITLE
fix: remove registry-url to avoid OIDC token conflict

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - run: npm ci
 


### PR DESCRIPTION
Removes registry-url from setup-node action to prevent NODE_AUTH_TOKEN being set, which conflicts with OIDC trusted publishing and causes 404 errors.