### PR TITLE
fix: add back registry-url for OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 


### PR DESCRIPTION
Re-adds registry-url to setup-node as it's needed for npm to recognize OIDC authentication.